### PR TITLE
refactor(mac): port mac implementation to work with v2

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,11 +2,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::process::Command;
 
-use crate::Error;
-
-pub fn is_implemented() -> bool {
-    true
-}
+use crate::{Error, ErrorKind, TrashItem};
 
 pub fn remove_all<I, T>(paths: I) -> Result<(), Error>
 where
@@ -17,20 +13,35 @@ where
         .into_iter()
         // Convert paths into canonical, absolute forms and collect errors
         .map(|path| {
-            path.as_ref()
-                .canonicalize()
-                .map_err(|e| Error::CanonicalizePath {
-                    code: e.raw_os_error(),
-                })
+            path.as_ref().canonicalize().map_err(|e| {
+                Error::new(
+                    ErrorKind::CanonicalizePath {
+                        original: path.as_ref().into(),
+                    },
+                    Box::new(e),
+                )
+            })
         })
         // Convert paths into &strs and collect errors
-        .map(|path| path.and_then(|p| p.to_str().ok_or(Error::Unknown).map(|s| s.to_owned())))
+        .map(|path| {
+            path.and_then(|p| {
+                match p.to_str() {
+                    Some(s) => Ok(s.to_owned()),
+                    None => Err(Error::kind_only(ErrorKind::ConvertOsString {
+                        // `PathBuf`s are stored as `OsString`s internally, so failure to convert
+                        // to a slice reduces appropriately.
+                        original: p.into(),
+                    })),
+                }
+            })
+        })
         .collect::<Result<Vec<String>, Error>>()?;
 
     // AppleScript command to move files (or directories) to Trash looks like
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
-    let mut command = Command::new("osascript");
+    const APPLESCRIPT: &str = "osascript";
+    let mut command = Command::new(APPLESCRIPT);
     let posix_files = full_paths
         .into_iter()
         .map(|p| format!("POSIX file \"{}\"", p))
@@ -45,14 +56,21 @@ where
     command.args(argv);
 
     // Execute command
-    let result = command.output().map_err(|e| Error::Remove {
-        code: e.raw_os_error(),
+    let result = command.output().map_err(|e| {
+        Error::new(
+            ErrorKind::PlatformApi {
+                function_name: APPLESCRIPT,
+                code: e.raw_os_error(),
+            },
+            Box::new(e),
+        )
     })?;
 
     if !result.status.success() {
-        return Err(Error::Remove {
+        return Err(Error::kind_only(ErrorKind::PlatformApi {
+            function_name: APPLESCRIPT,
             code: result.status.code(),
-        });
+        }));
     }
 
     Ok(())
@@ -60,4 +78,19 @@ where
 
 pub fn remove<T: AsRef<Path>>(path: T) -> Result<(), Error> {
     remove_all(&[path])
+}
+
+pub fn list() -> Result<Vec<TrashItem>, Error> {
+    unimplemented!();
+}
+
+pub fn purge_all<I>(_items: I) -> Result<(), Error>
+where
+    I: IntoIterator<Item = TrashItem>,
+{
+    unimplemented!();
+}
+
+pub fn restore_all<I>(_items: I) -> Result<(), Error> {
+    unimplemented!();
 }


### PR DESCRIPTION
Updates the existing Mac implementation to compile with v2 of the
library. Does not add any new functionality other defining required
methods.

Tests fail for methods relating to `list`, `purge_all`, or
`restore_all`, which are unimplemented.