### PR TITLE
Implement std::error::Error for trash::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,20 @@ impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			Self::Unknown => write!(f, "Unknown error"),
-			Self::CanonicalizePath { .. } => write!(f, "Error while canonicalizing path"),
-			Self::Remove { .. } => write!(f, "Error while performing the remove operation"),
+			Self::CanonicalizePath { code } => {
+				let code_str = match code {
+					Some(i) => format!("Error code was {}", i),
+					None => "No error code was available".into(),
+				};
+				write!(f, "Error while canonicalizing path. {}", code_str)
+			}
+			Self::Remove { code } => {
+				let code_str = match code {
+					Some(i) => format!("Error code was {}", i),
+					None => "No error code was available".into(),
+				};
+				write!(f, "Error while performing the remove operation. {}", code_str)
+			}
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::error;
+use std::fmt;
 use std::path::Path;
 
 #[cfg(test)]
@@ -32,6 +34,18 @@ pub enum Error {
 		code: Option<i32>,
 	},
 }
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Unknown => write!(f, "Unknown error"),
+			Self::CanonicalizePath { .. } => write!(f, "Error while canonicalizing path"),
+			Self::Remove { .. } => write!(f, "Error while performing the remove operation"),
+		}
+	}
+}
+
+impl error::Error for Error {}
 
 /// Removes a single file or directory.
 ///


### PR DESCRIPTION
Closes #16 
As mentioned in the issue, this would allow improved interoperability with error handling crates. I opted not to display the error code in `Display::fmt`, as I wasn't sure how the `None` case should be handled.